### PR TITLE
Fix mocking example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Spectator.describe Driver do
     # Call the mock method.
     subject.do_something(interface, dbl)
     # Verify everything went okay.
-    expect(interface).to have_received(:invoke).with(thing)
+    expect(interface).to have_received(:invoke).with(dbl)
   end
 end
 ```


### PR DESCRIPTION
When running the full example from the Mocks and Doubles section, the following error occurs from the last line of the example:

```
Error: Undefined local variable or method 'thing'
```

I realised that this should actually be `dbl`, changing it to this makes the test pass.