### PR TITLE
fix: `Error: expecting token 'CONST', not '::'`

### DIFF
--- a/src/spectator/dsl/mocks.cr
+++ b/src/spectator/dsl/mocks.cr
@@ -431,7 +431,7 @@ module Spectator::DSL
          # This isn't required, but new_mock() should still find this type.
          ::Spectator::DSL::Mocks::TYPES << {type.id.symbolize, @type.name(generic_args: false).symbolize, resolved.name.symbolize} %}
 
-      ::Spectator::Mock.inject({{base}}, ::{{resolved.name}}, {{**value_methods}}) {{block}}
+      ::Spectator::Mock.inject({{base}}, {{resolved.name}}, {{**value_methods}}) {{block}}
     end
 
     # Targets a stubbable object (such as a mock or double) for operations.


### PR DESCRIPTION
In crystal versions `1.13` and onward this bug is present. Spectator needs to stop adding the extra double colon prefix to avoid this error.

Example:

```console
There was a problem expanding macro 'inject'

Code in macro 'inject_mock'

 3 | ::Spectator::Mock.inject(:class, ::FS, )
     ^
Called macro defined in lib/spectator/src/spectator/mocks/mock.cr:149:5

 149 | macro inject(base, type_name, name = nil, **value_methods, &block)

Which expanded to:

 > 1 |
 > 2 |
 > 3 |         class ::::FS
                       ^
Error: expecting token 'CONST', not '::'
```

This change will most likely require an update to the `shard.yml` file to pin to a version of crystal `1.13` or higher and push out a new release to reflect these changes 🙇 